### PR TITLE
Add index route and event-gatekeeper component

### DIFF
--- a/app/components/event-gatekeeper.js
+++ b/app/components/event-gatekeeper.js
@@ -1,0 +1,26 @@
+import { alias } from '@ember/object/computed'
+import Component from '@ember/component'
+import { inject as service } from '@ember/service'
+
+export default Component.extend({
+  auth: service(),
+  user: alias('auth.credentials.email'),
+  admin: alias('auth.credentials.Admin'),
+  isAuthenticated: alias('auth.isAuthenticated'),
+  isAdmin: alias('auth.isAdmin'),
+  actions: {
+    updateDiscussion (discussion) {
+      console.log('updateDiscussion called on my-application.js')
+      console.log('discussion in my-application is is: ', discussion)
+      console.log('discussion title in my-application is ', discussion.get('title'))
+      return this.sendAction('updateDiscussion', discussion)
+    },
+    deleteDiscussion (discussion) {
+      return this.sendAction('deleteDiscussion', discussion)
+    },
+    createDiscussion (discussion) {
+      console.log('my-application.js discussion is', discussion)
+      return this.sendAction('createDiscussion', discussion)
+    }
+  }
+})

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -17,45 +17,6 @@ export default Route.extend({
     })
   },
   actions: {
-    updateDiscussion (discussion) {
-      console.log('discussion title in application.js is ', discussion.get('title'))
-      discussion.save()
-      .then(() => {
-        this.get('flashMessages').success('Discussion proposal updated.')
-      })
-      .then(() => this.refresh())
-      .catch(() => {
-        this.get('flashMessages')
-        .danger('There was a problem saving that update. Please try again.')
-      })
-    },
-    deleteDiscussion (discussion) {
-      discussion.destroyRecord()
-      .then(() => {
-        this.get('flashMessages').success('Proposal deleted.')
-      })
-      .then(() => this.refresh())
-      .catch(() => {
-        this.get('flashMessages')
-        .danger('There was a problem deleting that proposal. Please try again.')
-      })
-    },
-    createDiscussion (discussionPojo) {
-      console.log('application.js createDiscussion discussionPojo is: ', discussionPojo)
-      console.log('application.js discussionPojo.title is: ', discussionPojo.title)
-      // const updatedDiscussion = this.get('store').createRecord('discussion', {title: discussion.get('title')})
-      const emberDiscussion = this.get('store').createRecord('discussion', discussionPojo)
-      console.log('application.js discussion is', emberDiscussion)
-      return emberDiscussion.save()
-      .then(() => {
-        this.get('flashMessages').success('Discussion proposal saved.')
-      })
-      .then(() => this.refresh())
-      .catch(() => {
-        this.get('flashMessages')
-        .danger('There was a problem saving that proposal. Please try again.')
-      })
-    },
     signOut () {
       this.get('auth').signOut()
         .then(() => this.get('store').unloadAll())

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,0 +1,65 @@
+import Route from '@ember/routing/route'
+import { inject as service } from '@ember/service'
+import RSVP from 'rsvp'
+import { alias } from '@ember/object/computed'
+
+export default Route.extend({
+  flashMessages: service(),
+  auth: service(),
+  user: alias('auth.credentials.email'),
+  admin: alias('auth.credentials.Admin'),
+  isAuthenticated: alias('auth.isAuthenticated'),
+  isAdmin: alias('auth.isAdmin'),
+  model () {
+    // return this.get('store').findRecord('event', 1)
+    return RSVP.hash({
+      event: this.get('store').findRecord('event', 1),
+      discussions: this.get('store').findAll('discussion'),
+      timeslots: this.get('store').findAll('timeslot'),
+      newDiscussion: {}
+      // votes: this.get('store').findAll('vote')
+      // sessions: this.get('store').findAll('session')
+    })
+  },
+  actions: {
+    updateDiscussion (discussion) {
+      console.log('discussion title in application.js is ', discussion.get('title'))
+      discussion.save()
+      .then(() => {
+        this.get('flashMessages').success('Discussion proposal updated.')
+      })
+      .then(() => this.refresh())
+      .catch(() => {
+        this.get('flashMessages')
+        .danger('There was a problem saving that update. Please try again.')
+      })
+    },
+    deleteDiscussion (discussion) {
+      discussion.destroyRecord()
+      .then(() => {
+        this.get('flashMessages').success('Proposal deleted.')
+      })
+      .then(() => this.refresh())
+      .catch(() => {
+        this.get('flashMessages')
+        .danger('There was a problem deleting that proposal. Please try again.')
+      })
+    },
+    createDiscussion (discussionPojo) {
+      console.log('application.js createDiscussion discussionPojo is: ', discussionPojo)
+      console.log('application.js discussionPojo.title is: ', discussionPojo.title)
+      // const updatedDiscussion = this.get('store').createRecord('discussion', {title: discussion.get('title')})
+      const emberDiscussion = this.get('store').createRecord('discussion', discussionPojo)
+      console.log('application.js discussion is', emberDiscussion)
+      return emberDiscussion.save()
+      .then(() => {
+        this.get('flashMessages').success('Discussion proposal saved.')
+      })
+      .then(() => this.refresh())
+      .catch(() => {
+        this.get('flashMessages')
+        .danger('There was a problem saving that proposal. Please try again.')
+      })
+    }
+  }
+})

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,11 +1,12 @@
 {{!-- <span class="ember-tip">application.hbs</span>
 <span class="ember-tip">current path: {{this.currentPath}}</span> --}}
 {{my-application signOut="signOut"
-                 event=model.event
-                 timeslots=model.timeslots
+                 currentPath=currentPath
+                 event=model.event}}
+                 {{!-- timeslots=model.timeslots
                  discussions=model.discussions
                  newDiscussion=model.newDiscussion
                  currentPath=currentPath
                  createDiscussion='createDiscussion'
                  deleteDiscussion='deleteDiscussion'
-                 updateDiscussion='updateDiscussion'}}
+                 updateDiscussion='updateDiscussion'}} --}}

--- a/app/templates/components/event-gatekeeper.hbs
+++ b/app/templates/components/event-gatekeeper.hbs
@@ -1,0 +1,22 @@
+{{!-- <span class='ember-tip'>event.gatekeeper</span> --}}
+  {{#if event.proposalsOpen}}
+    {{propose-topics event=event
+                     discussions=discussions
+                     isAuthenticated=isAuthenticated
+                     isAdmin=isAdmin
+                     newDiscussion=newDiscussion
+                     createDiscussion='createDiscussion'
+                     deleteDiscussion='deleteDiscussion'
+                     updateDiscussion='updateDiscussion'}}
+  {{else if event.votingOpen}}
+    <p>Voting is open. (put a component here)</p>
+  {{else if event.scheduleFinalized}}
+    <p>Schedule is finalized. (put a component here)</p>
+    <ul>
+      {{#each timeslots as |timeslot|}}
+        <li>{{timeslot.startTime}} - {{timeslot.endTime}} ({{timeslot.roomName}})</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <p class='ember-tip'>Something's wrong. Can't figure out event status</p>
+  {{/if}}

--- a/app/templates/components/my-application.hbs
+++ b/app/templates/components/my-application.hbs
@@ -1,5 +1,6 @@
 {{!-- WORKING CLUES  --}}
-{{!-- {{#if isAdmin}}
+{{!-- <p class="ember-tip">my-application.hbs</p>
+{{#if isAdmin}}
 <span class="ember-tip">USER IS ADMIN</span>
 {{else if isAuthenticated}}
   <span class="ember-tip">USER IS NOT AN ADMIN</span>
@@ -29,7 +30,12 @@
 {{#bs-navbar type=(if inverse 'inverse') fluid=fluid collapsed=collapsed onCollapse=(action (mut collapsed) true) onExpand=(action (mut collapsed) false) as |navbar|}}
   <div class="navbar-header">
     {{navbar.toggle}}
-    <strong>{{#link-to "application" class="navbar-brand"}}Unscheduler{{/link-to}}</strong>
+    <strong>{{#link-to "application" class="navbar-brand"}}
+      Unscheduler > {{event.name}} >
+      {{#if event.proposalsOpen}} Proposing{{/if}}
+      {{#if event.votingOpen}} Voting{{/if}}
+      {{#if event.scheduleFinalized}} Schedule{{/if}}
+      {{/link-to}}</strong>
   </div>
   {{#navbar.content}}
     {{#navbar.nav class='navbar-right' as |nav|}}
@@ -47,8 +53,6 @@
   {{/navbar.content}}
 {{/bs-navbar}}
 
-<h1>{{event.name}}</h1>
-
 {{#each flashMessages.queue as |flash|}}
   {{flash-message flash=flash}}
 {{/each}}
@@ -56,28 +60,3 @@
 <div>
   {{outlet}}
 </div>
-
-<strong>
-  {{#if event.proposalsOpen}}
-    {{propose-topics event=event
-                     discussions=discussions
-                     isAuthenticated=isAuthenticated
-                     isAdmin=isAdmin
-                     newDiscussion=newDiscussion
-                     createDiscussion='createDiscussion'
-                     deleteDiscussion='deleteDiscussion'
-                     updateDiscussion='updateDiscussion'}}
-  {{else if event.votingOpen}}
-    <p>Voting is open. (put a component here)</p>
-  {{else if event.scheduleFinalized}}
-    <p>Schedule is finalized. (put a component here)</p>
-    <p class="ember-tip">this is trying to build a list of timeslots from RSVP within my-application.hbs</p>
-    <ul>
-      {{#each timeslots as |timeslot|}}
-        <li>{{timeslot.startTime}} - {{timeslot.endTime}} ({{timeslot.roomName}})</li>
-      {{/each}}
-    </ul>
-  {{else}}
-    <p>Something's wrong. Can't figure out event status</p>
-  {{/if}}
-</strong>

--- a/app/templates/components/propose-topics.hbs
+++ b/app/templates/components/propose-topics.hbs
@@ -7,7 +7,7 @@
   <h2>Discussion Ideas</h2>
   <p>{{#link-to 'sign-in'}}Sign in{{/link-to}} to propose an idea or vote on sessions.</p>
 {{/if}}
-
+ about to show discussion-list
 {{propose-topics/discussion-list discussions=discussions
                                  newDiscussion=newDiscussion
                                  isAuthenticated=isAuthenticated

--- a/app/templates/components/propose-topics/discussion-list.hbs
+++ b/app/templates/components/propose-topics/discussion-list.hbs
@@ -1,3 +1,4 @@
+
 <h3>Current Proposals</h3>
 {{#each discussions as |discussion|}}
   {{propose-topics/discussion-list/discussion discussion=discussion
@@ -5,12 +6,7 @@
                                               updateDiscussion='updateDiscussion'}}
 {{/each}}
 {{#if isAuthenticated}}
-
-<h3>Add a new proposal:</h3>
-{{propose-topics/discussion-list/new-discussion-form discussion=newDiscussion
-                                                     createDiscussion='createDiscussion'}}
+  <h3>Add a new proposal:</h3>
+  {{propose-topics/discussion-list/new-discussion-form discussion=newDiscussion
+                                                       createDiscussion='createDiscussion'}}
 {{/if}}
-{{!-- <form {{action 'createDiscussion' on='submit'}}>
-  {{input placeholder='New Discussion Topic'}}
-  <button type='submit'>Save</button>
-</form> --}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,0 +1,26 @@
+{{!-- <span class="ember-tip">index.hbs</span>
+{{#if isAdmin}}
+<span class="ember-tip">USER IS ADMIN</span>
+{{else if isAuthenticated}}
+  <span class="ember-tip">USER IS NOT AN ADMIN</span>
+{{else}}
+  <span class="ember-tip">NO ONE IS SIGNED IN</span>
+{{/if}}
+<p class="ember-tip">current path: {{this.currentPath}}</p>
+<ul class="ember-tip">
+<li>event is {{model.event}}</li>
+<li>event.name is {{model.event.name}}</li>
+<li>proposalsOpen: {{model.event.proposalsOpen}}</li>
+<li>votingOpen: {{model.event.votingOpen}}</li>
+<li>scheduleFinalized: {{model.event.scheduleFinalized}}</li>
+<li>maxVotes: {{model.event.maxVotes}}</li>
+</ul>
+
+<span class="ember-tip">about to show event-gatekeeper:</span> --}}
+{{event-gatekeeper event=model.event
+                   discussions=model.discussions
+                   timeslots=model.timeslots
+                   newDiscussion=model.newDiscussion
+                   createDiscussion='createDiscussion'
+                   deleteDiscussion='deleteDiscussion'
+                   updateDiscussion='updateDiscussion'}}

--- a/tests/integration/components/event-gatekeeper-test.js
+++ b/tests/integration/components/event-gatekeeper-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('event-gatekeeper', 'Integration | Component | event gatekeeper', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{event-gatekeeper}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#event-gatekeeper}}
+      template block text
+    {{/event-gatekeeper}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/routes/index-test.js
+++ b/tests/unit/routes/index-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:index', 'Unit | Route | index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
- Add `index` route so main content can be delivered via outlet rather
than pushed down when other routes appear
- Add event-gatekeeper component within index route since aliases don't
work on routes - here authentication can be checked to deliver appropriate
content
- Update the passing of data/functions up and down through parent
components
- Add event name and event status to nav bar display