### PR TITLE
Edit text in voting and schedule views

### DIFF
--- a/app/templates/components/event-gatekeeper.hbs
+++ b/app/templates/components/event-gatekeeper.hbs
@@ -9,22 +9,29 @@
                      deleteDiscussion='deleteDiscussion'
                      updateDiscussion='updateDiscussion'}}
   {{else if event.votingOpen}}
-    <p>Voting is open. (put a component here)</p>
+    <h3>Voting is Open!</h3>
+    <p>Your friendly event organizers love stickers and sticky notes, so they've
+    built an analog voting wall for you. You'll receive exactly
+    {{event.maxVotes}} stickers that you can put on your favorite sessions. Use
+    your votes wisely!</p>
+    <p>Go get your stickers and cast your votes!</p>
   {{else if event.scheduleFinalized}}
-    <p>Schedule is finalized. (put a component here)</p>
-    <h3>Sessions</h3>
+    <h3>Session Schedule</h3>
+    <p>The event organizers have counted the votes and scheduled the winning
+      sessions. Here's what you can look forward to today!</p>
+    <h4>Sessions</h4>
     <ul>
       {{#each event.displayTimes as |displayTime|}}
         <li>{{displayTime}}</li>
       {{/each}}
     </ul>
-    <h3>Rooms</h3>
+    <h4>Rooms</h4>
     <ul>
       {{#each event.roomNames as |roomName|}}
         <li>{{roomName}}</li>
       {{/each}}
     </ul>
-    <h3>Unordered Timeslots</h3>
+    <h4>Unordered Timeslots</h4>
     <ul>
       {{#each timeslots as |timeslot|}}
         <li>{{timeslot.startTime}} - {{timeslot.endTime}} ({{timeslot.roomName}})</li>


### PR DESCRIPTION
- Edit text that attendees see in the voting and scheduling screens
- Display the number of votes per person in the voting section in
`event-gatekeeper.hbs`